### PR TITLE
Uefi shell support

### DIFF
--- a/patches/0001-firmware-open-qemu-edk2.config-remove-shell_type.patch
+++ b/patches/0001-firmware-open-qemu-edk2.config-remove-shell_type.patch
@@ -1,0 +1,27 @@
+From 35f06169ad58eb63dd2ef4586906c852e31a7175 Mon Sep 17 00:00:00 2001
+From: Jani Hyvonen <jani.k.hyvonen@gmail.com>
+Date: Tue, 2 Sep 2025 09:49:02 +0300
+Subject: [PATCH] firmware-open: qemu: edk2.config remove shell_type
+
+Set the SHELL_TYPE parameter only in the build script
+which calls edk2.sh. This is to avoid double
+configuration during build time.
+
+Signed-off-by: Jani Hyvonen <jani.k.hyvonen@gmail.com>
+---
+ models/qemu/edk2.config | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/models/qemu/edk2.config b/models/qemu/edk2.config
+index e72d944..274a0e2 100644
+--- a/models/qemu/edk2.config
++++ b/models/qemu/edk2.config
+@@ -4,5 +4,4 @@ PLATFORM_BOOT_TIMEOUT=2
+ PS2_KEYBOARD_ENABLE=TRUE
+ SECURE_BOOT_ENABLE=TRUE
+ SERIAL_DRIVER_ENABLE=FALSE
+-SHELL_TYPE=NONE
+ TPM_ENABLE=TRUE
+-- 
+2.43.0
+

--- a/platform/q35/Makefile
+++ b/platform/q35/Makefile
@@ -7,6 +7,16 @@ WAYOUT := $(shell exec ip route get 1.1.1.1 | grep -oP 'src \K\S+')
 PORT := 10022
 MEM := -m 8G
 
+ifeq ($(CLEAN_USB),1)
+  $(shell rm -f $(BASE_DIR)/build/usbstick.img)
+endif
+
+ifeq ($(UEFI_SHELL),1)
+  UEFI_BOOT_APP := ${BASE_DIR}/uefi/firmware-open/edk2/Build/UefiPayloadPkgX64/DEBUG_COREBOOT/X64/Shell.efi
+else
+  UEFI_BOOT_APP := dummy
+endif
+
 # VIRTIO not working yet in the uefi payload, please fix
 ifeq ($(OPENFW),1)
 KERNEL :=
@@ -81,7 +91,8 @@ QEMUCMD := $(QEMUCMD) -device virtio-gpu-gl-pci,id=gpu0 -display egl-headless -s
 endif
 
 $(BASE_DIR)/build/usbstick.img:
-	$(BASE_DIR)/scripts/mkusbstickimg.sh $(BASE_DIR)/build/usbstick.img 2048
+	$(BASE_DIR)/scripts/mkusbstickimg.sh $(BASE_DIR)/build/usbstick.img 2048 \
+	$(UEFI_BOOT_APP)
 
 run: $(BASE_DIR)/build/usbstick.img
 	@echo "------------------------------------------------------------------------------------------"

--- a/scripts/mkusbstickimg.sh
+++ b/scripts/mkusbstickimg.sh
@@ -3,6 +3,7 @@ set -e
 
 IMG_FILE=$1
 IMG_SIZE=$2
+UEFI_BOOT_APP=$3
 VOLUME_LABEL="12345"
 
 echo "Creating clean ${IMG_SIZE}MB raw disk image..."
@@ -28,6 +29,15 @@ fi
 echo "Formatting partition ${LOOP_DEV}p1 with high compatibility..."
 # Format the partition with the specified label
 sudo mkfs.fat -F 32 -n "${VOLUME_LABEL}" "${LOOP_DEV}p1"
+
+if [ -f "${UEFI_BOOT_APP}" ]; then
+  mkdir ${BASE_BUILD_DIR}/usb-mnt
+  sudo mount ${LOOP_DEV}p1 ${BASE_BUILD_DIR}/usb-mnt
+  sudo mkdir -p ${BASE_BUILD_DIR}/usb-mnt/efi/boot
+  sudo cp ${UEFI_BOOT_APP} ${BASE_BUILD_DIR}/usb-mnt/efi/boot/BOOTX64.efi
+  sudo umount ${BASE_BUILD_DIR}/usb-mnt
+  rm -r ${BASE_BUILD_DIR}/usb-mnt
+fi
 
 echo "Cleaning up loopback device..."
 sudo losetup -d "${LOOP_DEV}"


### PR DESCRIPTION
Add support for copying bootable efi application into the USB media.
If Shell.efi is built and UEFI_SHELL=1 is used when calling "make run" the Shell.efi is copied to USB media and renamed to BOOTX64.efi to enable automated boot to shell.

Add support for cleaning USB media (to enable generating the content again).
This is handy when going back and forth with different USB content. Invoke by setting CLEAN_USB=1 when calling "make run"

Move uefi shell_type configuration to happen only by build scripts (previously overlapping configuration in qemu/edk2.config and calling script). Apply patch patches/0001-firmware-open-qemu-edk2.config-remove-shell_type.patch
to take this into use.