### PR TITLE
q35: usb image: add signed efi boot app to usb

### DIFF
--- a/platform/q35/Makefile
+++ b/platform/q35/Makefile
@@ -13,8 +13,7 @@ endif
 
 ifeq ($(UEFI_SHELL),1)
   UEFI_BOOT_APP := ${FWOPEN}/edk2/Build/UefiPayloadPkgX64/DEBUG_COREBOOT/X64/Shell.efi
-else
-  UEFI_BOOT_APP := dummy
+  KSMI_TEST_APP := ${FWOPEN}/edk2/Build/UefiPayloadPkgX64/DEBUG_COREBOOT/X64/KSMItApp.efi
 endif
 
 # VIRTIO not working yet in the uefi payload, please fix
@@ -86,13 +85,19 @@ QEMUCMD := $(QEMU) $(QEMUOPTS) \
 	   -serial file:$(BASE_DIR)/tty0.log -serial file:$(BASE_DIR)/tty1.log -serial file:$(BASE_DIR)/tty2.log
 endif
 
+ifeq ($(VNC),1)
+# Use "ssh -L 5901:localhost:5901 <username>@<remote host>" to tunnel VNC to your local machine
+# Use remmina or equivalent to view the display at localhost (connect to localhost:5901)
+QEMUCMD := $(QEMUCMD) -vnc 127.0.0.1:1
+endif
+
 ifeq ($(GRAPHICS),1)
 QEMUCMD := $(QEMUCMD) -device virtio-gpu-gl-pci,id=gpu0 -display egl-headless -spice $(SPICEOPTS) $(VDAGENT)
 endif
 
 $(BASE_DIR)/build/usbstick.img:
 	$(BASE_DIR)/scripts/mkusbstickimg.sh $(BASE_DIR)/build/usbstick.img 2048 \
-	$(UEFI_BOOT_APP)
+	$(UEFI_BOOT_APP) $(KSMI_TEST_APP)
 	@if [ ! -e $(BASE_DIR)/build/firmware-clean.rom ]; then \
 		cp $(BASE_DIR)/build/firmware.rom $(BASE_DIR)/build/firmware-clean.rom || true; \
 	fi

--- a/scripts/mkusbstickimg.sh
+++ b/scripts/mkusbstickimg.sh
@@ -4,8 +4,12 @@ set -e
 IMG_FILE=$1
 IMG_SIZE=$2
 UEFI_BOOT_APP=$3
+KSMI_TEST_APP=$4
 VOLUME_LABEL="12345"
 MARKER_FILE="KS.BAK"
+
+[ -z "$PRIVATEKEY" ] && PRIVATEKEY="$BASE_BUILD_DIR/keydata/MOK-DB.priv"
+[ -z "$PUBLICKEY" ] && PUBLICKEY="$BASE_BUILD_DIR/keydata/MOK-DB.pem"
 
 echo "Creating clean ${IMG_SIZE_MB}MB raw disk image..."
 dd if=/dev/zero of="${IMG_FILE}" bs=1M count=${IMG_SIZE}
@@ -31,14 +35,33 @@ sudo mount -o loop,offset=$((2048 * 512)) "${IMG_FILE}" "${MOUNT_POINT}"
 # Create the empty marker file
 sudo touch "${MOUNT_POINT}/${MARKER_FILE}"
 # Add uefi boot app if requested
-if [ -f "${UEFI_BOOT_APP}" ]; then
+if [ -n "${UEFI_BOOT_APP}" ] && [ -f "${UEFI_BOOT_APP}" ]; then
   echo "Adding ${UEFI_BOOT_APP} to USB media"
   sudo mkdir -p ${MOUNT_POINT}/efi/boot
-  sudo cp ${UEFI_BOOT_APP} ${MOUNT_POINT}/efi/boot/BOOTX64.efi
+	sbsign  --key $PRIVATEKEY \
+		--cert $PUBLICKEY ${UEFI_BOOT_APP} \
+		--output $BASE_BUILD_DIR/BOOTX64.app.efi.signed
+  sudo cp $BASE_BUILD_DIR/BOOTX64.app.efi.signed ${MOUNT_POINT}/efi/boot/BOOTX64.efi
+fi
+# SMI test application
+if [ -n "${KSMI_TEST_APP}" ] && [ -f "${KSMI_TEST_APP}" ]; then
+  echo "Adding ${KSMI_TEST_APP} to USB media"
+  sudo mkdir -p ${MOUNT_POINT}/efi/boot
+	sbsign  --key $PRIVATEKEY \
+		--cert $PUBLICKEY ${KSMI_TEST_APP} \
+		--output $BASE_BUILD_DIR/KSMItApp.efi.signed
+  sudo cp $BASE_BUILD_DIR/KSMItApp.efi.signed ${MOUNT_POINT}/efi/boot/KSMItApp.efi
 fi
 
 # Unmount and clean up
-sudo umount "${MOUNT_POINT}"
+sudo sync
+sudo umount -l "${MOUNT_POINT}"
+
+while grep -qs "$MOUNT_POINT" /proc/mounts; do
+  printf "."
+  sleep 1
+done
+
 rmdir "${MOUNT_POINT}"
 
 echo "Done, compatible image '${IMG_FILE}' is ready."


### PR DESCRIPTION
Additionally this patch adds support for copying
additional signed (test) application into USB.

Also VNC support for viewing QEMU window remotely
is added.