### PR TITLE
firmware-open: make: add a setup recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ openfw:
 openfw-clean:
 	@./scripts/build-of.sh clean
 
+openfw-setup:
+	@./scripts/build-of.sh setup
+
 kernel:
 	@cp scripts/nixos_* $(KERNEL_DIR)/arch/x86/configs/
 	$(MAKE) CC="$(CC)" -C$(KERNEL_DIR) -j$(NJOBS) nixos_defconfig bzImage modules

--- a/scripts/build-of.sh
+++ b/scripts/build-of.sh
@@ -13,6 +13,14 @@ if [ "x$1" = "xclean" ]; then
 	exit 0
 fi
 
+if [ "x$1" = "xsetup" ]; then
+	pushd $FWOPEN
+	git submodule update --init --checkout --recursive
+	git lfs pull
+	popd
+	exit 0
+fi
+
 if [ ! -e "$XGXX" ]; then
 	cd $FWOPEN/coreboot
 	make crossgcc CPUS=$(nproc)


### PR DESCRIPTION
To complete firmware-open specific environment setup.

This will pull some additional 3rd party implementation as well as few large binary deliveries.